### PR TITLE
Fix typos in descriptions

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -661,7 +661,7 @@ function exitFullscreen() {
  * Gets the current URL. Note: when using the
  * p5 Editor, this will return an empty object because the sketch
  * is embedded in an iframe. It will work correctly if you view the
- * sketch using sketch the editor's present or share URLs.
+ * sketch using the editor's present or share URLs.
  * @method getURL
  * @return {String} url
  * @example
@@ -692,7 +692,7 @@ p5.prototype.getURL = () => location.href;
  * Gets the current URL path as an array. Note: when using the
  * p5 Editor, this will return an empty object because the sketch
  * is embedded in an iframe. It will work correctly if you view the
- * sketch using sketch the edtior's present or share URLs.
+ * sketch using the editor's present or share URLs.
  * @method getURLPath
  * @return {String[]} path components
  * @example
@@ -714,7 +714,7 @@ p5.prototype.getURLPath = () =>
  * Gets the current URL params as an Object. Note: when using the
  * p5 Editor, this will return an empty object because the sketch
  * is embedded in an iframe. It will work correctly if you view the
- * sketch using sketch the edtior's present or share URLs.
+ * sketch using the editor's present or share URLs.
  * @method getURLParams
  * @return {Object} URL params
  * @example


### PR DESCRIPTION
Resolves [#1037](https://github.com/processing/p5.js-website/issues/1037)

The description text for the methods getURL, getURLPath and getURLParams had typos.


 Changes:

The phrase 

> sketch using sketch the edtior's present or share URLs.

was changed to 

> sketch using the editor's present or share URLs.


#### PR Checklist

- [x] [Inline documentation] is included / updated
